### PR TITLE
Fix for SQLA >=0.9

### DIFF
--- a/splinext/pokedex/controllers/pokedex_search.py
+++ b/splinext/pokedex/controllers/pokedex_search.py
@@ -1156,8 +1156,8 @@ class PokedexSearchController(PokedexBaseController):
                     func.min(chain_sorting_species.id).label('chain_position')
                 ).select_from(chain_sorting_alias) \
                 .filter(chain_sorting_species.id.in_(pokemon_ids)) \
-                .outerjoin((chain_sorting_species, 'species')) \
-                .outerjoin((chain_sorting_forms, 'default_form')) \
+                .outerjoin((chain_sorting_species, chain_sorting_alias.species)) \
+                .outerjoin((chain_sorting_forms, chain_sorting_alias.default_form)) \
                 .group_by(chain_sorting_species.evolution_chain_id) \
                 .subquery()
 


### PR DESCRIPTION
This fixes issue #101, which is caused by a change in SQLA introduced in 0.9 The change causes all searches that use "sort by evolution chain" to fail, resulting in a 500 error.
The code for the fix was provided by magical.
